### PR TITLE
Small text improvements

### DIFF
--- a/src/components/TheConsumptionParameters.vue
+++ b/src/components/TheConsumptionParameters.vue
@@ -33,7 +33,7 @@ const iReduction = ref(props.reduction2023);
   >
     <n-space>
       <n-input-group>
-        <n-input-group-label>Energiebedarf</n-input-group-label>
+        <n-input-group-label>Verbrauch im letzten Jahr</n-input-group-label>
         <n-input-number
           v-model:value="iConsumption"
           :validator="validatePositive"
@@ -44,9 +44,10 @@ const iReduction = ref(props.reduction2023);
         >
           <template #suffix>kWh</template></n-input-number
         >
+        <n-space>siehe letzte Gasrechnung</n-space>
       </n-input-group>
       <n-input-group>
-        <n-input-group-label>Davon spare ich 2023</n-input-group-label>
+        <n-input-group-label>Das will ich einsparen</n-input-group-label>
         <n-space>
           <n-input-number
             v-model:value="iReduction"

--- a/src/components/TheGasCalculator.vue
+++ b/src/components/TheGasCalculator.vue
@@ -88,11 +88,11 @@ const savings = computed(() => [0, 0, calculation2023.value.saved]);
         @reduction2023-changed="reduction2023 = $event"
       />
       <p style="padding-top: 1rem">
-        Basierend auf Deinem Verbrauch, der Einsparung und
+        Basierend auf deinem Verbrauch, der Einsparung und
         <n-el class="show-price" @click="togglePriceParameters" tag="a"
-          >einiger Annahmen zur Preisen und Preisentwicklung
+          >einigen Annahmen zu Preisen und Preisentwicklung
         </n-el>
-        schätzen wir ab, wie sich Deine Ausgaben in 2023 entwickeln
+        schätzen wir ab, wie sich Deine Ausgaben in 2023 entwickeln.
       </p>
       <ThePriceParameters
         v-if="showPriceParameter"

--- a/src/components/ThePriceParameters.vue
+++ b/src/components/ThePriceParameters.vue
@@ -69,9 +69,8 @@ watch(
       </n-input-group>
 
       <p>
-        Gib den Arbeitspreis Deines Vertrags an. Monatliche Grundgebühren sind
-        von der Förderung ausgenommen und werden in diesem Rechner nicht
-        berücksichtigt.
+        Gib den Arbeitspreis deines Vertrags an. Monatliche Grundgebühren sind
+        von der Förderung ausgenommen und werden hier nicht berücksichtigt.
       </p>
       <n-input-group>
         <n-input-group-label>Gaspreis 2021</n-input-group-label>

--- a/src/components/TheResult.vue
+++ b/src/components/TheResult.vue
@@ -45,20 +45,19 @@ onMounted(animateResult);
         €
       </p>
       <p>
-        Durch Deine Einsparung von
-        {{ reduction2023 }}kWh reduzierst Du nicht nur Emissionen, sondern
-        sparst auch richtig Geld!
+        Durch deine Einsparung von {{ reduction2023 }}kWh reduzierst du nicht
+        nur CO<sub>2</sub>, sondern sparst auch richtig Geld!
       </p>
     </n-card>
 
     <n-card :bordered="false">
       <p>
-        Wie sich Deine Kosten entwickelt haben bzw. entwickeln können, siehst Du
+        Wie sich deine Kosten entwickelt haben bzw. entwickeln können, siehst du
         im folgenden Diagramm.
       </p>
       <p>
-        Wir zeigen Dir hier an, in welchem Jahr Dein Verbrauch welche Kosten
-        verursachen würde. Keine Sorge: Zahlen musst Du nur den Eigenanteil.
+        Wir zeigen dir hier an, in welchem Jahr dein Verbrauch welche Kosten
+        verursachen würde. Keine Sorge: Zahlen musst du nur den Eigenanteil.
       </p>
       <ResultCharts
         :years="years"
@@ -67,9 +66,8 @@ onMounted(animateResult);
         :savings="savings"
       />
       <p>
-        Beachte dennoch: Die staatlichen Förderungen sind nur für 2023
-        garantiert. Was 2024 kommt, weiß noch niemand – nur dass das, was Du
-        nicht verbrauchst ganz sicher Deine Kosten senkt!
+        Wie es ab 2024 aussieht, weiß jetzt noch niemand.
+        Klar ist aber: was du einsparst, senkt deine Kosten immer.
       </p>
     </n-card>
   </n-space>

--- a/src/views/IntroView.vue
+++ b/src/views/IntroView.vue
@@ -11,7 +11,7 @@ import { CalculatorOutline as CalculatorIcon } from "@vicons/ionicons5";
   >
     <n-space>
       <p>
-        Gas wird teurer oder ist es schon. Mit der nur jährlichen Abrechnung kommt die
+        Gas wird teurer oder ist es schon. Mit der jährlichen Abrechnung kommt die
         böse Überraschung oft erst spät. Höhere Beiträge, aber auch Nachzahlungen schmerzen.
       </p>
 
@@ -26,7 +26,7 @@ import { CalculatorOutline as CalculatorIcon } from "@vicons/ionicons5";
       </p>
 
       <p>
-        Unser Gas-Rechner beantwortet deine Fragen und erklärt dir was es bringt, weniger zu
+        Unser Gas-Rechner beantwortet deine Fragen und erklärt dir, was es bringt, weniger zu
         duschen, effizienter zu kochen oder die Heizung ein Grad runter zu drehen.
       </p>
 


### PR DESCRIPTION
I made some sentences a little shorter and easier to read.

In german, one should use the lower case "du" and "deine", and use upper case only if in direct dialogue with someone directly (see https://www.duden.de/sprachwissen/sprachratgeber/Gross-oder-Kleinschreibung-von-duDu-und-ihrIhr), so I've unified that.