### PR TITLE
Simple form for entering contact mail address

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -17,12 +17,14 @@ declare module '@vue/runtime-core' {
     NForm: typeof import('naive-ui')['NForm']
     NFormItem: typeof import('naive-ui')['NFormItem']
     NIcon: typeof import('naive-ui')['NIcon']
+    NInput: typeof import('naive-ui')['NInput']
     NInputNumber: typeof import('naive-ui')['NInputNumber']
     NLayout: typeof import('naive-ui')['NLayout']
     NLayoutContent: typeof import('naive-ui')['NLayoutContent']
     NLayoutFooter: typeof import('naive-ui')['NLayoutFooter']
     NLayoutHeader: typeof import('naive-ui')['NLayoutHeader']
     NMenu: typeof import('naive-ui')['NMenu']
+    NMessageProvider: typeof import('naive-ui')['NMessageProvider']
     NModal: typeof import('naive-ui')['NModal']
     NNumberAnimation: typeof import('naive-ui')['NNumberAnimation']
     NSlider: typeof import('naive-ui')['NSlider']
@@ -41,5 +43,6 @@ declare module '@vue/runtime-core' {
     TheNavigation: typeof import('./src/components/TheNavigation.vue')['default']
     ThePriceParameters: typeof import('./src/components/ThePriceParameters.vue')['default']
     TheResult: typeof import('./src/components/TheResult.vue')['default']
+    TheStayInTouchForm: typeof import('./src/components/TheStayInTouchForm.vue')['default']
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import type {
-  GlobalTheme, 
-  GlobalThemeOverrides,
-} from "naive-ui";
-import TheNavigation from "./components/TheNavigation.vue";
-import TheFooter from "./components/TheFooter.vue";
+import type { GlobalTheme, GlobalThemeOverrides } from "naive-ui";
+import TheNavigation from "@/components/TheNavigation.vue";
+import TheFooter from "@/components/TheFooter.vue";
+import TheStayInTouchForm from "@/components/TheStayInTouchForm.vue";
 
 // const osThemeRef = useOsTheme()
 //const theme = ref((osThemeRef.value === 'dark' ? darkTheme : null) as GlobalTheme | null)
@@ -17,14 +15,15 @@ const themeOverrides: GlobalThemeOverrides = {
     primaryColor: "#00AAE8FF",
     primaryColorHover: "#00BBFFFF",
     primaryColorPressed: "#0B5976FF",
-    primaryColorSuppl: "#338FB1FF"
+    primaryColorSuppl: "#338FB1FF",
   },
   Card: {
-    colorEmbedded: 'rgba(213, 245, 255, 1)'
-  }
-}
+    colorEmbedded: "rgba(213, 245, 255, 1)",
+  },
+};
 
-const themeEditorStyle = localStorage.getItem('theme') === 'true' ? {} : {display: 'none'}
+const themeEditorStyle =
+  localStorage.getItem("theme") === "true" ? {} : { display: "none" };
 </script>
 
 <template>
@@ -35,9 +34,16 @@ const themeEditorStyle = localStorage.getItem('theme') === 'true' ? {} : {displa
           <TheNavigation />
         </n-layout-header>
         <n-layout-content>
-          <n-card centered>
-            <RouterView />
-          </n-card>
+          <n-message-provider>
+            <n-space vertical>
+              <n-card centered>
+                <RouterView />
+              </n-card>
+              <n-card :embedded="true">
+                <TheStayInTouchForm />
+              </n-card>
+            </n-space>
+          </n-message-provider>
         </n-layout-content>
         <n-layout-footer>
           <TheFooter />

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,7 +13,7 @@ declare module '@vue/runtime-core' {
     NForm: typeof import('naive-ui')['NForm']
     NFormItem: typeof import('naive-ui')['NFormItem']
     NIcon: typeof import('naive-ui')['NIcon']
-    NInput: typeof import('naive-ui')['NInputNumber']
+    NInput: typeof import('naive-ui')['NInput']
     NInputGroupLabel: typeof import('naive-ui')['NInputGroupLabel']
     NInputNumber: typeof import('naive-ui')['NInputNumber']
     NModal: typeof import('naive-ui')['NModal']

--- a/src/components/TheStayInTouchForm.vue
+++ b/src/components/TheStayInTouchForm.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import type { FormInst, FormItemRule, FormRules } from "naive-ui";
+import { getMatomo } from "@/lib/Matomo";
+
+const message = useMessage();
+const STORAGE_KEY = "email-submitted";
+const REGEXP_EMAIL = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
+
+const storedEmail = ref(localStorage.getItem(STORAGE_KEY));
+
+const formRef = ref<FormInst | null>(null);
+const model = ref({
+  email: "",
+});
+
+const rules: FormRules = {
+  email: {
+    type: "email",
+    required: true,
+    validator: function (rule: FormItemRule, value: any) {
+      return REGEXP_EMAIL.test(value)
+        ? undefined
+        : new Error("Bitte gib eine gültige E-Mail-Adresse ein");
+    },
+  },
+};
+
+const emailValidationStatus = computed(() => {
+  if (!model.value.email) {
+    return undefined;
+  }
+  return REGEXP_EMAIL.test(model.value.email) ? undefined : "error";
+});
+
+const handleSubmitClicked = async () => {
+  formRef.value?.restoreValidation();
+  try {
+    await formRef.value?.validate();
+
+    const Matomo = await getMatomo();
+    Matomo.trackEvent("explicit", "email", model.value.email);
+    localStorage.setItem(STORAGE_KEY, model.value.email);
+    storedEmail.value = model.value.email;
+    message.success("👍 Danke für Deine E-Mail-Adresse!");
+  } catch (validationErrors) {
+    (validationErrors as Array<Array<Error>>).forEach((a) =>
+      a.forEach((e) => message.error(e.message))
+    );
+  }
+};
+</script>
+
+<template>
+  <n-form ref="formRef" :model="model" :rules="rules" v-if="!storedEmail">
+    <p>
+      Wir wollen unseren Rechner immer mal wieder erweitern. Wenn Du auf dem
+      Laufenden bleiben willst, kannst Du uns hier vollkommen freiwillig Deine
+      E-Mail-Adresse hinterlassen.
+    </p>
+    <n-space horizontal>
+      <n-form-item :validation-status="emailValidationStatus" path="email">
+        <n-input
+          type="text"
+          v-model:value="model.email"
+          placeholder="Deine E-Mail-Adresse"
+        />
+      </n-form-item>
+      <n-form-item>
+        <n-button
+          type="primary"
+          :disabled="!model.email"
+          @click="handleSubmitClicked"
+        >
+          Übermitteln
+        </n-button>
+      </n-form-item>
+    </n-space>
+
+    <p>
+      Versprochen: Wir nutzen sie nicht für Werbezwecke, geben sie nicht weiter
+      oder machen sonst irgendein komisches Zeug mit ihr!
+    </p>
+  </n-form>
+</template>


### PR DESCRIPTION
Fixes #87 

On submit, the email-address is persisted in the local storage and sent as event to Matomo.
This way, we somehow have it (in form of the tracked event) and might transfer it lateron to some database (by reading the local storage on load)